### PR TITLE
[WIP] Immersion; Hide coordinates from users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 Teleport Potion
 
+This is a modification of the teleport_potion mod by TenPlus1, which focuses on
+immersion. The goal is to
+  - limit the teleport targets to known locations
+  - increase immersion by hiding coordinates from the normal player
+  - stay compatible with the original mod
+    - players with the `teleport` privilege can still set any coordinates
+
 This minetest mod adds both a teleportation potion and pad to the game
 
 https://forum.minetest.net/viewtopic.php?f=9&t=9234

--- a/init.lua
+++ b/init.lua
@@ -75,9 +75,13 @@ end
 local teleport_destinations = {}
 
 function set_teleport_destination(playername, dest)
-	minetest.chat_send_player(playername,
-			"Marked destination: " .. minetest.pos_to_string(dest))
 	teleport_destinations[playername] = dest
+	tp_effect(dest)
+	minetest.sound_play("portal_open", {
+		pos = dest,
+		gain = 1.0,
+		max_hear_distance = 10
+	})
 end
 
 --------------------------------------------------------------------------------

--- a/init.lua
+++ b/init.lua
@@ -263,10 +263,10 @@ minetest.register_node("teleport_potion:pad", {
 		}
 		local coords = coords.x .. "," .. coords.y .. "," .. coords.z
 		local desc = meta:get_string("desc")
-		formspec = "field[desc;" .. S("Description") .. ";" .. desc .. "]"
+		formspec = "field[desc;" .. S("Description") .. ";"
+				.. minetest.formspec_escape(desc) .. "]"
 		-- Only allow privileged players to change coordinates
-		local has_priv = minetest.get_player_privs(name)["teleport"]
-		if has_priv then
+		if minetest.check_player_privs(name, "teleport") then
 			formspec = formspec ..
 					"field[coords;" .. S("Teleport coordinates") .. ";" .. coords .. "]"
 		end
@@ -287,6 +287,8 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	end
 	local name = player:get_player_name()
 	local context = teleport_formspec_context[name]
+	if not context then return false end
+	teleport_formspec_context[name] = nil
 	local meta = minetest.get_meta(context.pos)
 	-- Coordinates were changed
 	if fields.coords and fields.coords ~= context.coords then
@@ -308,7 +310,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		meta:set_string("infotext", S("Pad Active (@1,@2,@3)",
 			coords.x, coords.y, coords.z))
 	end
-
 	return true
 end)
 


### PR DESCRIPTION
The goal is to limit the target destinations to known coordinates (where the player has already been), so that one could not simply teleport -5000 underground to find caves.
For that reason I changed the way how one sets the target position.
The new way how to set up a teleport pad (or potion) is to
  1. Equip pad / potion
  2. Punch a node (this sets the target coordinates)
  3. Place the pad / potion

No need to manually enter any coordinates (which increases immersion).
On the other hand, players with the "teleport" privilege can still set any coordinates by right-clicking the placed pad (though not with the potions).

This modification aims to be compatible with already placed pads: the teleportation part is not affected at all. Though it breaks the enchanting part, meaning: already placed pads have to be dug and rebuild to set new coordinates.